### PR TITLE
Added CachedSchema database support

### DIFF
--- a/src/main/java/org/picmg/redfish_server_template/RFmodels/custom/CachedSchema
+++ b/src/main/java/org/picmg/redfish_server_template/RFmodels/custom/CachedSchema
@@ -1,0 +1,71 @@
+package org.picmg.redfish_server_template.RFmodels.custom;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * POJO wrapper for json_schema table entries.
+ */
+@Document("json_schema")
+public class CachedSchema {
+  @Field("_id")
+  @Id
+  private ObjectId _id;
+
+  @JsonProperty("source")
+  @Field("source")
+  private String source;
+
+  @JsonProperty("schema")
+  @Field("schema")
+  private Map<String, Object> schema;
+
+  public String getSource() {return source;}
+  public Map<String, Object> getSchema() {
+    return schema;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CachedSchema obj = (CachedSchema) o;
+    return Objects.equals(this.source, obj.source) &&
+        Objects.equals(this.schema, obj.schema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(source, schema);
+  }
+
+  @Override
+  public String toString() {
+      return "class CachedSchema {\n" +
+            "    source: " + toIndentedString(source) + "\n" +
+            "    schema: " + toIndentedString(schema) + "\n" +
+            "}";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/src/main/java/org/picmg/redfish_server_template/repository/CachedSchemaRepository
+++ b/src/main/java/org/picmg/redfish_server_template/repository/CachedSchemaRepository
@@ -1,0 +1,37 @@
+//******************************************************************************************************
+// TaskRepository.java
+//
+// Interface for TaskRepository.
+//
+//Copyright (C) 2022, PICMG.
+//
+//        This program is free software: you can redistribute it and/or modify
+//        it under the terms of the GNU General Public License as published by
+//        the Free Software Foundation, either version 3 of the License, or
+//        (at your option) any later version.
+//
+//        This program is distributed in the hope that it will be useful,
+//        but WITHOUT ANY WARRANTY; without even the implied warranty of
+//        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//        GNU General Public License for more details.
+//
+//        You should have received a copy of the GNU General Public License
+//        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//*******************************************************************************************************
+
+
+package org.picmg.redfish_server_template.repository;
+
+import org.picmg.redfish_server_template.RFmodels.custom.CachedSchema;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.util.List;
+
+public interface CachedSchemaRepository extends MongoRepository<CachedSchema, String> {
+    @Query(value="{ 'Id' : ?0 }")
+    CachedSchema getById(String Id);
+
+    @Query(value="{ 'source' : ?0 }")
+    CachedSchema getFirstBySource(String source);
+}


### PR DESCRIPTION
In preparation for later updates, the MongoDB database now is built to include a table of schema metadata.  This commit adds Java support to access the database table.